### PR TITLE
Update for compatibility with Redmine 3.4

### DIFF
--- a/app/views/issues/show.html.erb
+++ b/app/views/issues/show.html.erb
@@ -118,7 +118,7 @@
 	end	
   end
 end %>
-<%= render_custom_fields_rows(@issue) %>
+<%= render_full_width_custom_fields_rows(@issue) %>
 <%= call_hook(:view_issues_show_details_bottom, :issue => @issue) %>
 </div>
 
@@ -209,4 +209,4 @@ end %>
     <%= auto_discovery_link_tag(:atom, {:format => 'atom', :key => User.current.rss_key}, :title => "#{@issue.project} - #{@issue.tracker} ##{@issue.id}: #{@issue.subject}") %>
 <% end %>
 
-<%= context_menu issues_context_menu_path %>
+<%= context_menu %>


### PR DESCRIPTION
In Redmine 3.4  render_custom_fields_rows was replaced by render_full_width_custom_fields_rows and context_menu takes no parameters.